### PR TITLE
Value & pull secret improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,12 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
-## [2.2.0] - 2025-04-16
+## [3.0.0] - 2025-04-17
+
+### Changed
+
+- Stop creating the namespace and manually copying the image pull secret to it; it is now the responsibility of the ExternalSecret
+  to handle this.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
   - `Fixed` for any bugfixes.
   - `Security` in case of vulnerabilities.
 
+## [2.2.0] - 2025-04-16
+
+### Added
+
+- New optional parameter `value_file`; use it to add a value file to the helm deployment command.
+
 ## [2.1.0] - 2025-03-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Categories, defined in [changemap.json](.github/clq/changemap.json):
 - Stop creating the namespace and manually copying the image pull secret to it; it is now the responsibility of the ExternalSecret
   to handle this.
 
+### Removed
+
+- Remove the `-xv` before the call to helm. There is a single toggle of the shell trace and verbose mode, controlled by the action's verbose parameter.
+
 ### Added
 
 - New optional parameter `value_file`; use it to add a value file to the helm deployment command.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ The phases can map to one or many aws accounts and clusters.
 In order to support the case of all phases into a single cluster, a module is deployed to a namespace that identify both the module and the phase.
 The naming pattern will be `<phase>-<module name>`.
 
-This action expects configuration values for the chart for the *phase* in `src/main/helm/values-${phase}.yaml`
+This action expects configuration values for the chart for the *phase* in `src/main/helm/values-${phase}.yaml`.
+
+This action supports a 2nd configuration values to be used. This is extending, not replacing, the default value files and is
+intended for deployment pipeline tha need to extract values from their environment at deployment time.
 
 ## Arguments
 

--- a/action.sh
+++ b/action.sh
@@ -92,15 +92,6 @@ buildTimeValues=("--values" "src/main/helm/values-${phase}.yaml")
 [ -n "${value_file}" ] && [ -r "${value_file}" ] && buildTimeValues+=("--values" "${value_file}")
 
 set -vx
-if [ "${dry_run:-false}" = "false" ]; then
-  /usr/local/bin/kubectl create namespace "${namespace}" --dry-run=client -o yaml |
-    /usr/local/bin/kubectl apply -f -
-
-  /usr/local/bin/kubectl get secret ghcr-secret --namespace=default -o json |
-    /usr/local/bin/jq 'del(.metadata["namespace","creationTimestamp","resourceVersion","selfLink","uid"])' |
-    /usr/local/bin/kubectl apply --namespace="${namespace}" -f -
-fi
-
 /usr/local/bin/helm upgrade --install --render-subchart-notes \
   ${dry_run:+--dry-run} ${verbose:+--debug} "${waitOrAtomic[@]}" \
   --create-namespace --namespace "${namespace}" \

--- a/action.sh
+++ b/action.sh
@@ -91,7 +91,6 @@ fi
 buildTimeValues=("--values" "src/main/helm/values-${phase}.yaml")
 [ -n "${value_file}" ] && [ -r "${value_file}" ] && buildTimeValues+=("--values" "${value_file}")
 
-set -vx
 /usr/local/bin/helm upgrade --install --render-subchart-notes \
   ${dry_run:+--dry-run} ${verbose:+--debug} "${waitOrAtomic[@]}" \
   --create-namespace --namespace "${namespace}" \

--- a/action.sh
+++ b/action.sh
@@ -50,6 +50,9 @@ for i in "$@"; do
   TIMEOUT=*)
     readonly timeout="${i#*=}"
     ;;
+  VALUE_FILE=*)
+    readonly value_file="${i#*=}"
+    ;;
   # if VERBOSE is true, create the variable, otherwise recognize that it exists but without creating the variable
   # Overridden by GitHub Workflow's verbosity
   VERBOSE=true)
@@ -85,6 +88,9 @@ else
   waitOrAtomic+=("--atomic" "--cleanup-on-fail")
 fi
 
+buildTimeValues=("--values" "src/main/helm/values-${phase}.yaml")
+[ -n "${value_file}" ] && [ -r "${value_file}" ] && buildTimeValues+=("--values" "${value_file}")
+
 set -vx
 if [ "${dry_run:-false}" = "false" ]; then
   /usr/local/bin/kubectl create namespace "${namespace}" --dry-run=client -o yaml |
@@ -97,9 +103,9 @@ fi
 
 /usr/local/bin/helm upgrade --install --render-subchart-notes \
   ${dry_run:+--dry-run} ${verbose:+--debug} "${waitOrAtomic[@]}" \
-  --namespace "${namespace}" \
+  --create-namespace --namespace "${namespace}" \
   --timeout "${timeout}" \
-  --values "src/main/helm/values-${phase}.yaml" \
+  "${buildTimeValues[@]}" \
   --set "global.CLUSTER_IAM=arn:aws:iam::${cluster_iam}" --set "global.AWS_REGION=${aws_region}" \
   --set "global.phase=${phase}" \
   --version "${chart_version}" "${module_name}" "${helm_registry}/${chart_name}"

--- a/action.yaml
+++ b/action.yaml
@@ -43,6 +43,10 @@ inputs:
     description: "time to wait for the deployment to succeed (a Go duration, default 5m0s)"
     required: false
     default: "5m0s"
+  value_file:
+    description: "name of a file containing additional values for helm"
+    required: false
+    default: ""
   verbose:
     description: "enable verbose output"
     required: false
@@ -63,4 +67,5 @@ runs:
     - "NAMESPACE=${{ inputs.namespace && inputs.namespace || format('{0}-{1}', inputs.phase, inputs.module_name ) }}"
     - "PHASE=${{ inputs.phase }}"
     - "TIMEOUT=${{ inputs.timeout }}"
+    - "VALUE_FILE=${{ inputs.value_file }}"
     - "VERBOSE=${{ inputs.verbose }}"


### PR DESCRIPTION
Two tickets in this PR:
1. make it possible to define values for the helm chart at deployment time
2. remove the manual namespace creation and population of the image pull secret